### PR TITLE
feat: simplify logging infrastructure to single log group

### DIFF
--- a/infrastructure/bin/nailit-app.ts
+++ b/infrastructure/bin/nailit-app.ts
@@ -2,6 +2,7 @@
 import 'source-map-support/register';
 import * as cdk from 'aws-cdk-lib';
 import { NailItInfrastructureStack } from '../lib/nailit-infrastructure-stack';
+import { LoggingStack } from '../lib/logging-stack';
 
 const app = new cdk.App();
 
@@ -35,7 +36,18 @@ if (!envConfig) {
   throw new Error(`Unknown environment: ${environment}. Must be one of: ${Object.keys(environments).join(', ')}`);
 }
 
+// Deploy main infrastructure stack
 new NailItInfrastructureStack(app, `NailIt-${envConfig.resourceSuffix}`, {
+  env: {
+    account: accountId,
+    region: region,
+  },
+  environment: environment,
+  envConfig: envConfig,
+});
+
+// Deploy logging infrastructure stack
+new LoggingStack(app, `LoggingStack-${envConfig.resourceSuffix}`, {
   env: {
     account: accountId,
     region: region,


### PR DESCRIPTION
Infrastructure cleanup: Simplifies logging to single CloudWatch log group with context-based filtering. Removes unused log groups (errors, security, performance) and maintains all functionality. Aligns CDK with actual implementation for production-ready simplicity.