### PR TITLE
fix: inject NAILIT_ENVIRONMENT into Next.js runtime

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -34,6 +34,13 @@ frontend:
         - npx prisma generate
     build:
       commands:
+        - echo "Injecting environment variables for Next.js runtime..."
+        - env | grep -e NAILIT_ENVIRONMENT >> .env.production || echo "NAILIT_ENVIRONMENT not set"
+        - env | grep -e NAILIT_AWS_REGION >> .env.production || echo "NAILIT_AWS_REGION not set"  
+        - env | grep -e LOG_LEVEL >> .env.production || echo "LOG_LEVEL not set"
+        - env | grep -e DISABLE_CLOUDWATCH_LOGS >> .env.production || echo "DISABLE_CLOUDWATCH_LOGS not set"
+        - echo "Contents of .env.production:"
+        - cat .env.production || echo "No .env.production file created"
         - npm run build -- --no-lint
   artifacts:
     baseDirectory: .next


### PR DESCRIPTION
Critical build fix to inject environment variables at build time. Adds NAILIT_ENVIRONMENT and other logging variables to .env.production during Amplify build so they're available at Next.js runtime. Without this, the environment detection code can't access the variables even when they're set in Amplify Console. Includes build-time debugging to verify variable injection.