### PR TITLE
Fix environment detection consistency in debug-env endpoint

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -34,6 +34,13 @@ frontend:
         - npx prisma generate
     build:
       commands:
+        - echo "Injecting environment variables for Next.js runtime..."
+        - env | grep -e NAILIT_ENVIRONMENT >> .env.production || echo "NAILIT_ENVIRONMENT not set"
+        - env | grep -e NAILIT_AWS_REGION >> .env.production || echo "NAILIT_AWS_REGION not set"  
+        - env | grep -e LOG_LEVEL >> .env.production || echo "LOG_LEVEL not set"
+        - env | grep -e DISABLE_CLOUDWATCH_LOGS >> .env.production || echo "DISABLE_CLOUDWATCH_LOGS not set"
+        - echo "Contents of .env.production:"
+        - cat .env.production || echo "No .env.production file created"
         - npm run build -- --no-lint
   artifacts:
     baseDirectory: .next

--- a/app/api/debug-env/route.ts
+++ b/app/api/debug-env/route.ts
@@ -13,22 +13,71 @@ export async function GET() {
     };
   };
 
-  // Detect environment based on DATABASE_URL
-  const dbUrl = process.env.DATABASE_URL || 'NOT_SET';
-  let detectedEnvironment = 'unknown';
-  
-  if (dbUrl.includes('misty-frog')) {
-    detectedEnvironment = 'production';
-  } else if (dbUrl.includes('raspy-sound')) {
-    detectedEnvironment = 'staging';
-  } else if (dbUrl.includes('still-paper')) {
-    detectedEnvironment = 'development';
+  // Use the same environment detection logic as the logger
+  function detectEnvironment(): string {
+    // Primary: Use our custom environment variable
+    const nailItEnv = process.env.NAILIT_ENVIRONMENT;
+    
+    if (nailItEnv) {
+      switch (nailItEnv.toLowerCase()) {
+        case 'development':
+        case 'dev':
+          return 'development';
+        case 'staging':
+        case 'stage':
+          return 'staging';
+        case 'production':
+        case 'prod':
+          return 'production';
+        default:
+          console.warn(`Unknown NAILIT_ENVIRONMENT: ${nailItEnv}, defaulting to development`);
+          return 'development';
+      }
+    }
+    
+    // Fallback: Try AWS_BRANCH (in case Amplify ever provides it)
+    const awsBranch = process.env.AWS_BRANCH;
+    if (awsBranch) {
+      switch (awsBranch) {
+        case 'develop':
+          return 'development';
+        case 'staging':
+          return 'staging';
+        case 'main':
+          return 'production';
+        default:
+          return 'development';
+      }
+    }
+    
+    // Fallback: DATABASE_URL analysis (legacy method)
+    const dbUrl = process.env.DATABASE_URL || 'NOT_SET';
+    if (dbUrl.includes('misty-frog')) {
+      return 'production';
+    } else if (dbUrl.includes('raspy-sound')) {
+      return 'staging';
+    } else if (dbUrl.includes('still-paper')) {
+      return 'development';
+    }
+    
+    // Fallback: NODE_ENV for local development
+    const nodeEnv = process.env.NODE_ENV;
+    if (nodeEnv === 'development' || nodeEnv === 'test') {
+      return 'development';
+    }
+    
+    // Default fallback
+    return 'development';
   }
+
+  const detectedEnvironment = detectEnvironment();
 
   const envConfig = {
     // Environment Detection
     detectedEnvironment,
     nodeEnv: process.env.NODE_ENV,
+    nailItEnvironment: process.env.NAILIT_ENVIRONMENT || 'NOT_SET',
+    awsBranch: process.env.AWS_BRANCH || 'NOT_SET',
     
     // NextAuth Configuration
     nextauth: {
@@ -40,7 +89,7 @@ export async function GET() {
     
     // Database Configuration
     database: {
-      url: secretInfo(dbUrl),
+      url: secretInfo(process.env.DATABASE_URL || 'NOT_SET'),
       migrationUrl: secretInfo(process.env.DATABASE_MIGRATION_URL),
       bothSet: !!(process.env.DATABASE_URL && process.env.DATABASE_MIGRATION_URL),
     },


### PR DESCRIPTION
Problem: debug-env endpoint used legacy DATABASE_URL detection while rest of app uses NAILIT_ENVIRONMENT. Solution: Updated to use same environment detection logic as logger, prioritizing NAILIT_ENVIRONMENT variable. Added transparency with nailItEnvironment and awsBranch in debug output.