### PR TITLE
Fix environment detection consistency in debug-env endpoint

### DIFF
--- a/app/api/debug-env/route.ts
+++ b/app/api/debug-env/route.ts
@@ -13,22 +13,71 @@ export async function GET() {
     };
   };
 
-  // Detect environment based on DATABASE_URL
-  const dbUrl = process.env.DATABASE_URL || 'NOT_SET';
-  let detectedEnvironment = 'unknown';
-  
-  if (dbUrl.includes('misty-frog')) {
-    detectedEnvironment = 'production';
-  } else if (dbUrl.includes('raspy-sound')) {
-    detectedEnvironment = 'staging';
-  } else if (dbUrl.includes('still-paper')) {
-    detectedEnvironment = 'development';
+  // Use the same environment detection logic as the logger
+  function detectEnvironment(): string {
+    // Primary: Use our custom environment variable
+    const nailItEnv = process.env.NAILIT_ENVIRONMENT;
+    
+    if (nailItEnv) {
+      switch (nailItEnv.toLowerCase()) {
+        case 'development':
+        case 'dev':
+          return 'development';
+        case 'staging':
+        case 'stage':
+          return 'staging';
+        case 'production':
+        case 'prod':
+          return 'production';
+        default:
+          console.warn(`Unknown NAILIT_ENVIRONMENT: ${nailItEnv}, defaulting to development`);
+          return 'development';
+      }
+    }
+    
+    // Fallback: Try AWS_BRANCH (in case Amplify ever provides it)
+    const awsBranch = process.env.AWS_BRANCH;
+    if (awsBranch) {
+      switch (awsBranch) {
+        case 'develop':
+          return 'development';
+        case 'staging':
+          return 'staging';
+        case 'main':
+          return 'production';
+        default:
+          return 'development';
+      }
+    }
+    
+    // Fallback: DATABASE_URL analysis (legacy method)
+    const dbUrl = process.env.DATABASE_URL || 'NOT_SET';
+    if (dbUrl.includes('misty-frog')) {
+      return 'production';
+    } else if (dbUrl.includes('raspy-sound')) {
+      return 'staging';
+    } else if (dbUrl.includes('still-paper')) {
+      return 'development';
+    }
+    
+    // Fallback: NODE_ENV for local development
+    const nodeEnv = process.env.NODE_ENV;
+    if (nodeEnv === 'development' || nodeEnv === 'test') {
+      return 'development';
+    }
+    
+    // Default fallback
+    return 'development';
   }
+
+  const detectedEnvironment = detectEnvironment();
 
   const envConfig = {
     // Environment Detection
     detectedEnvironment,
     nodeEnv: process.env.NODE_ENV,
+    nailItEnvironment: process.env.NAILIT_ENVIRONMENT || 'NOT_SET',
+    awsBranch: process.env.AWS_BRANCH || 'NOT_SET',
     
     // NextAuth Configuration
     nextauth: {
@@ -40,7 +89,7 @@ export async function GET() {
     
     // Database Configuration
     database: {
-      url: secretInfo(dbUrl),
+      url: secretInfo(process.env.DATABASE_URL || 'NOT_SET'),
       migrationUrl: secretInfo(process.env.DATABASE_MIGRATION_URL),
       bothSet: !!(process.env.DATABASE_URL && process.env.DATABASE_MIGRATION_URL),
     },


### PR DESCRIPTION
## Problem The debug-env endpoint was using legacy DATABASE_URL-based environment detection while the rest of the application (logger, etc.) correctly uses the NAILIT_ENVIRONMENT variable. This caused inconsistent environment reporting. ## Solution - Updated debug-env endpoint to use the same environment detection logic as the logger - Prioritizes NAILIT_ENVIRONMENT variable over DATABASE_URL analysis - Added nailItEnvironment and awsBranch to debug output for transparency - Maintains DATABASE_URL analysis as fallback for backward compatibility ## Testing After deployment, https://develop.d1rq0k9js5lwg3.amplifyapp.com/api/debug-env should show: - detectedEnvironment: 'development' - nailItEnvironment: 'development' - nodeEnv: 'production' (expected in builds) ## Related - Fixes inconsistency noticed in build logs vs runtime environment detection - Ensures all endpoints use consistent environment detection logic