### PR TITLE
Fix CloudWatch environment logic in debug-env endpoint

### DIFF
--- a/app/api/debug-env/route.ts
+++ b/app/api/debug-env/route.ts
@@ -116,8 +116,8 @@ export async function GET() {
       logLevel: process.env.LOG_LEVEL || 'environment-default',
       cloudWatchDisabled: process.env.DISABLE_CLOUDWATCH_LOGS === 'true',
       nodeEnv: process.env.NODE_ENV || 'NOT_SET',
-      cloudWatchConfigured: !!(process.env.NAILIT_AWS_REGION && process.env.NODE_ENV !== 'development'),
-      willLogToCloudWatch: !!(process.env.NAILIT_AWS_REGION && process.env.NODE_ENV !== 'development' && process.env.DISABLE_CLOUDWATCH_LOGS !== 'true'),
+      cloudWatchConfigured: !!(process.env.NAILIT_AWS_REGION && detectedEnvironment !== 'development'),
+      willLogToCloudWatch: !!(process.env.NAILIT_AWS_REGION && detectedEnvironment !== 'development' && process.env.DISABLE_CLOUDWATCH_LOGS !== 'true'),
     },
     
     // Quick Health Check


### PR DESCRIPTION
## Problem The logging section in debug-env was showing cloudWatchConfigured: true for development environment because it was checking NODE_ENV !== 'development', but NODE_ENV is always 'production' in Amplify builds. ## Solution - Use detectedEnvironment instead of NODE_ENV for CloudWatch logic - CloudWatch should be disabled in development environment regardless of NODE_ENV - detectedEnvironment correctly reflects the actual environment ## Expected Result After deployment, debug-env should show: - cloudWatchConfigured: false (for development) - willLogToCloudWatch: false (for development) - nodeEnv: 'production' (still expected in builds)